### PR TITLE
Updating the core version of ubuntu now that Xenial (16.04) is losing support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile for base collectd install
 
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 MAINTAINER Sebastian Estevez estevezsebastian@gmail.com
 
 # Install all apt-get utils and required repos


### PR DESCRIPTION
Perhaps we should also upgrade gradle and migrate to openjdk 8 as well, but thought this would just be more targeted.